### PR TITLE
App Crashes in release version 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
 'use strict'
-var ReactNative = require('react-native')
-var {
-    NativeModules
-} = ReactNative
+var NativeModules = require('react-native').NativeModules
 /*
  * Get React Native server IP if hostname is `localhost`
  * On Android emulator, the IP of host is `10.0.2.2` (Genymotion: 10.0.3.2)


### PR DESCRIPTION
 NativeModules = window.require('NativeModules') is not correct , need to do it like this :  
var ReactNative = require('react-native')
var {
    NativeModules
} = ReactNative