### PR TITLE
Fix `window.require` issue on RN 0.56

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function getByRemoteConfig(hostname) {
     var serverHost = constants.ServerHost || hostname
     return { hostname: serverHost.split(':')[0], passed: true }
   }
-  return hostname
+  return { hostname: hostname, passed: false }
 }
 
 function getConstants(config) {
@@ -72,7 +72,7 @@ function getByRNRequirePolyfill(hostname) {
 module.exports = function (hostname) {
   // Check if it in React Native environment
   if (
-    typeof __fbBatchedBridge !== 'object' ||  // Not on react-native
+    typeof __fbBatchedBridge !== 'object' ||
     hostname !== 'localhost' && hostname !== '127.0.0.1'
   ) {
     return hostname

--- a/index.js
+++ b/index.js
@@ -11,14 +11,14 @@ function getByRemoteConfig(hostname) {
   if (
     !Array.isArray(remoteModuleConfig) ||
     hostname !== 'localhost' && hostname !== '127.0.0.1'
-  ) return hostname
+  ) return { hostname: hostname, passed: false }
 
   var constants = (
     remoteModuleConfig.find(getConstants) || []
   )[1]
   if (constants) {
     var serverHost = constants.ServerHost || hostname
-    return serverHost.split(':')[0]
+    return { hostname: serverHost.split(':')[0], passed: true }
   }
   return hostname
 }
@@ -27,18 +27,7 @@ function getConstants(config) {
   return config && (config[0] === 'AndroidConstants' || config[0] === 'PlatformConstants')
 }
 
-/*
- * Get React Native server IP if hostname is `localhost`
- * On Android emulator, the IP of host is `10.0.2.2` (Genymotion: 10.0.3.2)
- */
-module.exports = function (hostname) {
-  if (
-    typeof __fbBatchedBridge !== 'object' ||  // Not on react-native
-    hostname !== 'localhost' && hostname !== '127.0.0.1'
-  ) {
-    return hostname
-  }
-  hostname = getByRemoteConfig(hostname)
+function getByRNRequirePolyfill(hostname) {
   var originalWarn = console.warn
   console.warn = function() {
     if (arguments[0] && arguments[0].indexOf('Requiring module \'NativeModules\' by name') > -1) return
@@ -74,4 +63,27 @@ module.exports = function (hostname) {
     AndroidConstants.ServerHost
   ) || hostname
   return serverHost.split(':')[0]
+}
+
+/*
+ * Get React Native server IP if hostname is `localhost`
+ * On Android emulator, the IP of host is `10.0.2.2` (Genymotion: 10.0.3.2)
+ */
+module.exports = function (hostname) {
+  // Check if it in React Native environment
+  if (
+    typeof __fbBatchedBridge !== 'object' ||  // Not on react-native
+    hostname !== 'localhost' && hostname !== '127.0.0.1'
+  ) {
+    return hostname
+  }
+  const result = getByRemoteConfig(hostname)
+
+  // Leave if get hostname by remote config successful
+  if (result.passed) {
+    return result.hostname
+  }
+
+  // Otherwise, use RN's require polyfill
+  return getByRNRequirePolyfill(hostname)
 }

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function getByRNRequirePolyfill(hostname) {
     typeof window.require !== 'function' ||
     // RN >= 0.56
     // TODO: Get NativeModules for RN >= 0.56
-    typeof window.require === 'metroRequire'
+    typeof window.require.name === 'metroRequire'
   ) {
     return hostname
   }

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = function (hostname) {
   ) {
     return hostname
   }
-  const result = getByRemoteConfig(hostname)
+  var result = getByRemoteConfig(hostname)
 
   // Leave if get hostname by remote config successful
   if (result.passed) {

--- a/index.js
+++ b/index.js
@@ -48,7 +48,14 @@ module.exports = function (hostname) {
   var NativeModules
   var PlatformConstants
   var AndroidConstants
-  if (typeof window === 'undefined' || !window.__DEV__ || typeof window.require !== 'function') {
+  if (
+    typeof window === 'undefined' ||
+    !window.__DEV__ ||
+    typeof window.require !== 'function' ||
+    // RN >= 0.56
+    // TODO: Get NativeModules for RN >= 0.56
+    typeof window.require === 'metroRequire'
+  ) {
     return hostname
   }
   NativeModules = window.require('NativeModules')


### PR DESCRIPTION
I temporarily disabled `require` NativeModules for RN >= 0.56. Although it won't get NativeModules, but we have `getByRemoteConfig` should work with most cases.