### PR TITLE
Fix the Unknown named module: 'NativeModules' after upgrading to Reac…

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function getByRNRequirePolyfill(hostname) {
   ) {
     return hostname
   }
-  NativeModules = window.require('NativeModules')
+  NativeModules = require('react-native').NativeModules
   console.warn = originalWarn
   if (
     !NativeModules ||


### PR DESCRIPTION
https://user-images.githubusercontent.com/32485179/42338049-de945918-8088-11e8-9610-73e99c02f677.png
Got the error after upgrading to react-native 0.56.0 using the 1.x version of Reactotron. Not sure if this is fixed here. Please take a look. Thanks.