### PR TITLE
fixed weird "indexOf is undefined" bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function getConstants(config) {
 function getByRNRequirePolyfill(hostname) {
   var originalWarn = console.warn
   console.warn = function() {
-    if (arguments[0] && arguments[0].indexOf('Requiring module \'NativeModules\' by name') > -1) return
+    if (arguments[0] && typeof arguments[0].indexOf == 'function' && arguments[0].indexOf('Requiring module \'NativeModules\' by name') > -1) return
     return originalWarn.apply(console, arguments)
   }
 


### PR DESCRIPTION
after upgrading to rn 0.59, using remote-redux-devtools, i was running into this weird issue when trying to use `console.warn(obj)` where `obj !== typeof 'string'`.

![Simulator Screen Shot - iPhone X - 2019-03-26 at 13 59 47](https://user-images.githubusercontent.com/3315507/54999177-fc3a1400-4fcf-11e9-98f1-eee9e063453d.png)

i don't exactly understand what the function does and why.. but this works around the issue.